### PR TITLE
增加parsetext()函数，将html文本转化为虚拟DOM对象，避免错误解析关联资源

### DIFF
--- a/115RenamePlus.js
+++ b/115RenamePlus.js
@@ -121,6 +121,21 @@
             clearInterval(interval);
         }
     }
+	
+    /**
+     * html文本转换为虚拟Document对象
+     * @param {String} text
+     * @returns {Document}
+     */
+     function parsetext(text) {
+        try {
+            let doc = document.implementation.createHTMLDocument('');
+            doc.documentElement.innerHTML = text;
+            return doc;
+        } catch (e) {
+            console.log('parse error');
+        }
+    }
 
     /**
      * 执行改名方法
@@ -219,7 +234,7 @@
                 method: "GET",
                 url: url_s,
                 onload: xhr => {
-                    let response = $(xhr.responseText);
+                    let response = $(parsetext(xhr.responseText));
                     if (!(response.find("div.alert").length)) {
 						/*
                         // 标题
@@ -258,7 +273,7 @@
 							method: "GET",
 							url: moviePage,
 							onload: xhr => {
-								let response = $(xhr.responseText);
+								let response = $(parsetext(xhr.responseText));
 								// 标题
 								title = response
 								    .find("h3")
@@ -345,7 +360,7 @@
 		            method: "GET",
 		            url: moviePage,
 		            onload: xhr => {
-		                let response = $(xhr.responseText);
+		                let response = $(parsetext(xhr.responseText));
 		                // 标题
 		                title = response
 		                    .find("h3")
@@ -423,7 +438,7 @@
                 method: "GET",
                 url: url_s,
                 onload: xhr => {
-                    let response = $(xhr.responseText);
+                    let response = $(parsetext(xhr.responseText));
 					/*
 					// 标题
 					title = response
@@ -460,7 +475,7 @@
 							method: "GET",
 							url: moviePage,
 							onload: xhr => {
-								let response = $(xhr.responseText);
+								let response = $(parsetext(xhr.responseText));
 								// 标题
 								title = response
 								    .find("h3")
@@ -547,7 +562,7 @@
                 method: "GET",
                 url: url_s,
                 onload: xhr => {
-                    let response = $(xhr.responseText);
+                    let response = $(parsetext(xhr.responseText));
                     if (!(response.find("div.alert").length)) {
 						/*
                         // 标题
@@ -586,7 +601,7 @@
 							method: "GET",
 							url: moviePage,
 							onload: xhr => {
-								let response = $(xhr.responseText);
+								let response = $(parsetext(xhr.responseText));
 								// 标题
 								title = response
 									.find("h3")
@@ -659,7 +674,7 @@
             onload: xhr => {
 				console.log("处理影片页 " + searchUrl + fh +"/");
                 // 匹配标题
-                let response = $(xhr.responseText);
+                let response = $(parsetext(xhr.responseText));
                 let title = response
                     .find("div.items_article_MainitemThumb img")
                     .attr("title");
@@ -719,7 +734,7 @@
             onload: xhr => {
 				console.log("处理影片页 " + searchUrl + fh +"/");
                 // 匹配标题
-                let response = $(xhr.responseText);
+                let response = $(parsetext(xhr.responseText));
                 let title = response
                     .find("div.common_detail_cover > h1")
                     .html()


### PR DESCRIPTION
原先直接用Jquery解析请求返回的html文本会导致解析了很多不必要的关联资源，例如Javbus页面中的各种图片，而且请求还错误指向了115域名下，一次改名就有几十个错误请求发出，过多的请求导致115会将其识别为网站攻击。只要一次性改5个以上文件就基本上会被识别为网站攻击，导致无法继续访问115。

所以增加parsetext()函数，将html文本转化为虚拟DOM对象。再把虚拟DOM对象给Jquery解析，避免解析关联资源。
